### PR TITLE
implement :child-config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# MASTER
+New option: `:child-config` enables to change processing as you go down levels
+
 # 0.1.7
 React Native: Also camelcase :style when passing a vector.
 Eg:

--- a/README.md
+++ b/README.md
@@ -57,13 +57,16 @@ A map with the following keys:
   not do the conversion. With a custom function you can fine tune which keys
   are converted and which are not.
 
+- `:child-config`: Called for every element with [config raw-element normalized-element] to get
+  a new configuration to process element's children with. This allows to keep track of levels in the
+  element tree, e.g. to create an `html` form, that adds attributes at the root.
+
 React Native special options:
 
 - `:no-string-tags?`: If set to `true`: Never output string tags (don't exits in react native)
 
 - `:default-ns`: Any unprefixed component will get prefixed with this namespace
   symbol (eg. `'foo.bar.xyz`)
-
 
 ## Third argument `handlers`
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ A map with the following keys:
   not do the conversion. With a custom function you can fine tune which keys
   are converted and which are not.
 
+- `:transform-fn`: Called with [[tag attrs children *env*]] before emitting, to get
+  transformed element as [tag attrs children]
+
 - `:child-config`: Called for every element with [config raw-element normalized-element] to get
   a new configuration to process element's children with. This allows to keep track of levels in the
   element tree, e.g. to create an `html` form, that adds attributes at the root.

--- a/src/hicada/compiler.clj
+++ b/src/hicada/compiler.clj
@@ -413,6 +413,8 @@
    o :inline? false - NOT supported yet. Possibly in the future...
    o :child-config - Called for every element with [config raw-element normalized-element]
                      to get a new configuration for element's children
+   o :transform-fn - Called with [[tag attrs children *env*]] before emitting, to get
+                     transformed element as [tag attrs children]
 
    React Native special recommended options:
    o :no-string-tags? - Never output string tags (don't exits in RN)

--- a/src/hicada/compiler.clj
+++ b/src/hicada/compiler.clj
@@ -36,11 +36,17 @@
                      ;; A fn that will get [tag attr children] and return
                      ;; [tag attr children] just before emitting.
                      :transform-fn identity
-                     :create-element 'js/React.createElement})
+                     :create-element 'js/React.createElement
+                     :child-config (fn [options form expanded] options)})
 
 (def ^:dynamic *config* default-config)
 (def ^:dynamic *handlers* default-handlers)
 (def ^:dynamic *env* nil)
+
+(defmacro with-child-config [form expanded-form & body]
+  `(let [cfg# *config*
+         new-cfg# ((:child-config *config*) *config* ~form ~expanded-form)]
+     (binding [*config* new-cfg#] ~@body)))
 
 (defmulti compile-react
           "Compile a Clojure data structure into a React fn call."
@@ -232,7 +238,9 @@
     (get *handlers* tag)
     (let [f (get *handlers* tag)
           [klass attrs children] (apply f element)]
-      (emit-react klass attrs (mapv compile-html children)))
+      (emit-react klass attrs
+                  (with-child-config element [klass attrs]
+                    (mapv compile-html children))))
 
     ;; e.g. [:span "foo"]
     ;(every? literal? element)
@@ -241,7 +249,9 @@
     ;; e.g. [:span {} x]
     (and (literal? tag) (map? attrs))
     (let [[tag attrs _] (norm/element [tag attrs])]
-      (emit-react tag attrs (mapv compile-html children)))
+      (emit-react tag attrs
+                  (with-child-config element [tag attrs]
+                    (mapv compile-html children))))
 
     (literal? tag)
     ;; We could now interpet this as either:
@@ -401,10 +411,13 @@
    o :camelcase-key-pred - defaults to (some-fn keyword? symbol?), ie. map keys that have
                            string keys, are NOT by default converted from kebab-case to camelCase!
    o :inline? false - NOT supported yet. Possibly in the future...
+   o :child-config - Called for every element with [config raw-element normalized-element]
+                     to get a new configuration for element's children
 
    React Native special recommended options:
    o :no-string-tags? - Never output string tags (don't exits in RN)
    o :default-ns - Any unprefixed component will get prefixed with this ns.
+   o :child-config - (fn [config raw-element normalized-element] -> config) change processing options as hicada goes down the tree
   - handlers:
    A map to handle special tags. See default-handlers in this namespace.
   - env: The macro environment. Not used currently."


### PR DESCRIPTION
Right now, it's hard to make element-processing tree-aware. This PR implements a `:child-config` option, taking a function to update hicada's `*config*` for each child level. With this, it's easy to create a tree-aware element transformation.

### My use case

Create a variant of the `html` form, taking a component identifier and adding an appropriate class to the root element, but not any child elements. With this PR, I could implement this like:

```cljs
{...
 :transorm-fn  root-transform-fn
 :child-config (fn [config _ _]
                 (assoc config
                        :transform-fn identity
                        :child-config (:child-config hicada/default-config)))
 ...}
```